### PR TITLE
Added dropdowns to process page sections in mobile devices

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@auth0/auth0-react": "^2.3.0",
+        "@radix-ui/react-accordion": "^1.2.11",
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-dropdown-menu": "^2.1.15",
         "@radix-ui/react-label": "^2.1.7",
@@ -896,6 +897,37 @@
       "integrity": "sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==",
       "license": "MIT"
     },
+    "node_modules/@radix-ui/react-accordion": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-1.2.11.tgz",
+      "integrity": "sha512-l3W5D54emV2ues7jjeG1xcyN7S3jnK3zE2zHqgn0CmMsy9lNJwmgcrmaxS+7ipw15FAivzKNzH3d5EcGoFKw0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-collapsible": "1.1.11",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-arrow": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz",
@@ -903,6 +935,36 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.11.tgz",
+      "integrity": "sha512-2qrRsVGSCYasSz1RFOorXwl0H7g7J1frQtgpQgYrt+MOidtPAINHn9CPovQXb83r8ahapdx3Tu0fa/pdFFSdPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@auth0/auth0-react": "^2.3.0",
+    "@radix-ui/react-accordion": "^1.2.11",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-dropdown-menu": "^2.1.15",
     "@radix-ui/react-label": "^2.1.7",

--- a/src/components/about-us/team-tab.tsx
+++ b/src/components/about-us/team-tab.tsx
@@ -14,7 +14,7 @@ export const TeamTab = ({ teamData, customTitle }: TeamTabProps) => {
       <h2 className=" mx-0 text-header3 text-[#fed7aa] pt-4">
         {teamData.length > 0 ? customTitle || teamData[0][0] : "Loading..."}
       </h2>
-      <hr className="h-1 m-2 bg-[#f97316] border-0 dark:bg-gray-700"></hr>
+      <hr className="h-1 m-2 bg-[#f97316] border-0"></hr>
       <div className="flex flex-row flex-wrap w-full justify-center">
         {teamData.map((personData, index) => (
           <Person

--- a/src/components/content/item-card.tsx
+++ b/src/components/content/item-card.tsx
@@ -94,7 +94,7 @@ export const ItemCard = memo(function ItemCard({
             <motion.div
               layoutId={`item-${category}-${id}`}
               ref={ref}
-              className="w-full max-w-[600px] mx-[1rem] h-fit my-auto md:h-fit md:max-h-[90%] flex flex-col bg-white dark:bg-neutral-900 sm:rounded-3xl overflow-hidden rounded-lg shadow-lg"
+              className="w-full max-w-[600px] mx-[1rem] h-fit my-auto md:h-fit md:max-h-[90%] flex flex-col bg-white sm:rounded-3xl overflow-hidden rounded-lg shadow-lg"
             >
               {/* Header with gradient background */}
               <motion.div
@@ -140,17 +140,17 @@ export const ItemCard = memo(function ItemCard({
 
               {/* Item Info */}
               <div className="p-4">
-                <div className="flex justify-between items-start">
-                  <div className="w-full">
+                <div className="flex justify-between items-start ">
+                  <div className="w-full ">
                     <motion.h3
                       layoutId={`title-${category}-${id}`}
-                      className="bg-[url(images/arrow.png)] bg-size-[70%_100%] bg-center bg-no-repeat py-2 text-white dark:text-neutral-200 poppins text-[24px] font-bold mb-4 text-center"
+                      className="bg-[url(images/arrow.png)] bg-size-[70%_100%] bg-center bg-no-repeat py-2 text-white poppins text-[24px] font-bold mb-4 text-center"
                     >
                       {activeItem.name}
                     </motion.h3>
                     <motion.p
                       layoutId={`description-${category}-${id}`}
-                      className="text-neutral-600 dark:text-neutral-400 text-base text-center text-body"
+                      className="text-neutral-600 text-base text-center text-body"
                     >
                       {activeItem.description}
                     </motion.p>

--- a/src/components/process-dropdown.tsx
+++ b/src/components/process-dropdown.tsx
@@ -1,0 +1,33 @@
+import {
+  Accordion,
+  AccordionItem,
+  AccordionTrigger,
+  AccordionContent,
+} from "@/components/ui/accordion";
+import type { ReactElement } from "react";
+import { useMediaQuery } from "react-responsive";
+
+interface ProcessDropdownProps {
+  value: string;
+  trigger: ReactElement;
+  content: ReactElement;
+}
+
+const ProcessDropdown = ({ value, trigger, content }: ProcessDropdownProps) => {
+  const isMobileDevice = useMediaQuery({ maxWidth: 768 });
+
+  return (
+    <Accordion
+      type="single"
+      collapsible={isMobileDevice}
+      defaultValue={isMobileDevice ? "" : value}
+    >
+      <AccordionItem value={value}>
+        <AccordionTrigger>{trigger}</AccordionTrigger>
+        <AccordionContent>{content}</AccordionContent>
+      </AccordionItem>
+    </Accordion>
+  );
+};
+
+export default ProcessDropdown;

--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -1,0 +1,68 @@
+import * as React from "react";
+import * as AccordionPrimitive from "@radix-ui/react-accordion";
+import { ChevronDownIcon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { useMediaQuery } from "react-responsive";
+
+function Accordion({
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Root>) {
+  return <AccordionPrimitive.Root data-slot="accordion" {...props} />;
+}
+
+function AccordionItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Item>) {
+  return (
+    <AccordionPrimitive.Item
+      data-slot="accordion-item"
+      className={cn("border-b last:border-b-0", className)}
+      {...props}
+    />
+  );
+}
+
+function AccordionTrigger({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Trigger>) {
+  const isMobileDevice = useMediaQuery({ maxWidth: 768 });
+  return (
+    <AccordionPrimitive.Header className="flex">
+      <AccordionPrimitive.Trigger
+        data-slot="accordion-trigger"
+        className={cn(
+          "focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-start justify-between gap-4 rounded-md py-4 text-left text-sm font-medium transition-all outline-none focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&[data-state=open]>svg]:rotate-180",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {isMobileDevice && (
+          <ChevronDownIcon className="text-muted-foreground pointer-events-none size-9 shrink-0 translate-y-7 transition-transform duration-200" />
+        )}
+      </AccordionPrimitive.Trigger>
+    </AccordionPrimitive.Header>
+  );
+}
+
+function AccordionContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Content>) {
+  return (
+    <AccordionPrimitive.Content
+      data-slot="accordion-content"
+      className="data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down overflow-hidden text-sm"
+      {...props}
+    >
+      <div className={cn("pt-0 pb-4", className)}>{children}</div>
+    </AccordionPrimitive.Content>
+  );
+}
+
+export { Accordion, AccordionItem, AccordionTrigger, AccordionContent };

--- a/src/pages/Process.tsx
+++ b/src/pages/Process.tsx
@@ -9,310 +9,339 @@ import ArrowButton from "@/components/ui/arrow-button";
 import { useNavigate } from "react-router-dom";
 import CharacterCarousel from "@/components/character-carousel";
 import TitleBanner from "@/components/ui/title-banner";
+import ProcessDropdown from "@/components/process-dropdown";
 
 const ProcessPage = () => {
-  const photo: string = "images/placeholder/placeholder.PNG";
   const navigate = useNavigate();
 
   return (
     <>
-      <main className="mt-0 px-6 md:px-12 relative bg-[url(images/items-background.png)] bg-[#BBB] bg-fixed bg-repeat bg-blend-difference bg-size-[90%] md:bg-size-[80%] *:text-white">
+      <main className="mt-0 px-6 md:px-12 relative bg-[url(images/items-background.png)] bg-[#BBB] bg-fixed bg-repeat bg-blend-difference bg-size-[90%] md:bg-size-[80%] *:text-white min-h-[80vh]">
         {/* About Project Section */}
         <div className="pt-5">
           <TitleBanner color="orange" text="The Process" className="mb-5" />
-          <h1 className="text-header2 pt-4 mx-0 mb-4"> About the Project</h1>
-          <div className="flex md:flex-row flex-col items-stretch">
-            <p className="text-body mb-4">
-              Gizmo Go-Kartz was constructed by a team of almost 50 RIT students
-              of varying grade levels, as an Entrepreneurial Co-op over the
-              summer of 2025 sponsored by RIT Professor Nicholas Buonarota. All
-              students are split into 8 sub-teams by their specialty:
-              <ul className="list-disc *:my-2 ml-5">
-                <li>
-                  <b className="font-bold text-[#fb923c]">Production:</b>{" "}
-                  Oversees the entire team's work, assigning tasks and handling
-                  marketing.
-                </li>
-                <li>
-                  <b className="font-bold text-[#fb923c]">
-                    Gameplay and Systems Programming:
-                  </b>{" "}
-                  Programs all of the game's features and mechanics in Unity.
-                </li>
-                <li>
-                  <b className="font-bold text-[#fb923c]">Web Development:</b>{" "}
-                  Programs the game's website, summarizing information and
-                  displaying game statistics.
-                </li>
-                <li>
-                  <b className="font-bold text-[#fb923c]">Level Design:</b>{" "}
-                  Designs and iterates on the layouts and themes of the game's
-                  tracks.
-                </li>
-                <li>
-                  <b className="font-bold text-[#fb923c]">
-                    Content Development:
-                  </b>{" "}
-                  Creates all the game's art assets and intellectual property.
-                </li>
-                <li>
-                  <b className="font-bold text-[#fb923c]">Quality Assurance:</b>{" "}
-                  Ensures code and documentation is well-organized through
-                  frequent testing.
-                </li>
-                <li>
-                  <b className="font-bold text-[#fb923c]">Support:</b> Assists
-                  other teams in various areas and ensures progress doesn't slow
-                  down.
-                </li>
-                <li>
-                  <b className="font-bold text-[#fb923c]">
-                    Research &amp; Development:
-                  </b>{" "}
-                  Researches construction of the game's arcade cabinet and
-                  potential features.
-                </li>
-              </ul>
-              The project and most of its students work in the school of
-              Interactive Games and Media, which is incorporated into the game's
-              marketing. A majority of the team works remotely, but team
-              meetings occur on-campus with all local members present, and all
-              remote members in a Zoom call. This project was developed over the
-              course of 2.5 months, stretching from late May to mid-August of
-              2025.
-            </p>
-            <div className="md:min-w-[400px] md:w-300">
-              <img
-                src="images/process/team-photo.jpg"
-                alt="Photo of the team"
-                className="md:ml-[2rem] md:mt-0 self-center md:self-end md:pr-4 w-[100%] h-[300px] mb-2"
-              />
-              <ArrowButton
-                caption="Meet the team!"
-                clickAction={() => navigate("/aboutUs")}
-                className="absolute right-5 md:right-8 font-semibold px-6 mt-[1rem] px-10 py-3"
-              />
-            </div>
-          </div>
+          <ProcessDropdown
+            value="about-project"
+            trigger={<h1 className="text-header2 my-4"> About The Project</h1>}
+            content={
+              <div className="flex md:flex-row flex-col items-stretch">
+                <p className="text-body mb-4">
+                  Gizmo Go-Kartz was constructed by a team of almost 50 RIT
+                  students of varying grade levels, as an Entrepreneurial Co-op
+                  over the summer of 2025 sponsored by RIT Professor Nicholas
+                  Buonarota. All students are split into 8 sub-teams by their
+                  specialty:
+                  <ul className="list-disc *:my-2 ml-5">
+                    <li>
+                      <b className="font-bold text-[#fb923c]">Production:</b>{" "}
+                      Oversees the entire team's work, assigning tasks and
+                      handling marketing.
+                    </li>
+                    <li>
+                      <b className="font-bold text-[#fb923c]">
+                        Gameplay and Systems Programming:
+                      </b>{" "}
+                      Programs all of the game's features and mechanics in
+                      Unity.
+                    </li>
+                    <li>
+                      <b className="font-bold text-[#fb923c]">
+                        Web Development:
+                      </b>{" "}
+                      Programs the game's website, summarizing information and
+                      displaying game statistics.
+                    </li>
+                    <li>
+                      <b className="font-bold text-[#fb923c]">Level Design:</b>{" "}
+                      Designs and iterates on the layouts and themes of the
+                      game's tracks.
+                    </li>
+                    <li>
+                      <b className="font-bold text-[#fb923c]">
+                        Content Development:
+                      </b>{" "}
+                      Creates all the game's art assets and intellectual
+                      property.
+                    </li>
+                    <li>
+                      <b className="font-bold text-[#fb923c]">
+                        Quality Assurance:
+                      </b>{" "}
+                      Ensures code and documentation is well-organized through
+                      frequent testing.
+                    </li>
+                    <li>
+                      <b className="font-bold text-[#fb923c]">Support:</b>{" "}
+                      Assists other teams in various areas and ensures progress
+                      doesn't slow down.
+                    </li>
+                    <li>
+                      <b className="font-bold text-[#fb923c]">
+                        Research &amp; Development:
+                      </b>{" "}
+                      Researches construction of the game's arcade cabinet and
+                      potential features.
+                    </li>
+                  </ul>
+                  The project and most of its students work in the school of
+                  Interactive Games and Media, which is incorporated into the
+                  game's marketing. A majority of the team works remotely, but
+                  team meetings occur on-campus with all local members present,
+                  and all remote members in a Zoom call. This project was
+                  developed over the course of 2.5 months, stretching from late
+                  May to mid-August of 2025.
+                </p>
+                <div className="md:min-w-[400px] md:w-300">
+                  <img
+                    src="images/process/team-photo.jpg"
+                    alt="Photo of the team"
+                    className="md:ml-[2rem] md:mt-0 self-center md:self-end md:pr-4 w-[100%] h-[300px] mb-2"
+                  />
+                  <ArrowButton
+                    caption="Meet the team!"
+                    clickAction={() => navigate("/aboutUs")}
+                    className="absolute right-5 md:right-8 font-semibold px-6 mt-[1rem] px-10 py-3"
+                  />
+                </div>
+              </div>
+            }
+          />
         </div>
 
         {/* Designing Game Section */}
-        <div>
-          <h1 className="text-header2 mt-[6rem] m-4 mx-0 mb-4">
-            Designing the Game
-          </h1>
-          <div className="flex md:flex-row flex-col items-stretch">
-            <p className="mr-8 text-body mb-4">
-              The look of Gizmo Go‑Kartz feels fun and nostalgic, echoing early
-              3D kart racers like Mario Kart 64. We use a simple, low‑poly art
-              style and a bold, RIT‑inspired color scheme, like warm reds,
-              oranges, and yellows that really popped against cooler tones you
-              see in other kart games. Our tracks take you to playful, cartoon
-              versions of RIT landmarks like the SHED and Global Village, and
-              racers are based on familiar IGM student characters—skaters,
-              dining workers, orientation leaders, and so on. The UI emulates
-              old‑school racing games, keeping everything clear and focused on
-              your racer. Altogether, the design is meant to capture the unique,
-              caffeine‑fuelled energy of IGM life in a fresh, polished
-              experience.
-            </p>
-            <img
-              src="images/RIT.jpg"
-              alt="Picture of RIT"
-              className="md:mt-0 self-center md:self-end md:w-[500px] w-full md:w-1/4 max-h-[400px]"
-            />
-          </div>
-        </div>
+        <ProcessDropdown
+          value="designing"
+          trigger={<h1 className="text-header2 my-4">Designing The Game</h1>}
+          content={
+            <div className="flex md:flex-row flex-col items-stretch">
+              <p className="mr-8 text-body mb-4">
+                The look of Gizmo Go‑Kartz feels fun and nostalgic, echoing
+                early 3D kart racers like Mario Kart 64. We use a simple,
+                low‑poly art style and a bold, RIT‑inspired color scheme, like
+                warm reds, oranges, and yellows that really popped against
+                cooler tones you see in other kart games. Our tracks take you to
+                playful, cartoon versions of RIT landmarks like the SHED and
+                Global Village, and racers are based on familiar IGM student
+                characters—skaters, dining workers, orientation leaders, and so
+                on. The UI emulates old‑school racing games, keeping everything
+                clear and focused on your racer. Altogether, the design is meant
+                to capture the unique, caffeine‑fuelled energy of IGM life in a
+                fresh, polished experience.
+              </p>
+              <img
+                src="images/RIT.jpg"
+                alt="Picture of RIT"
+                className="md:mt-0 self-center md:self-end md:w-[500px] w-full md:w-1/4 max-h-[400px]"
+              />
+            </div>
+          }
+        />
 
         {/* Character Dev Info Section */}
-        <div>
-          <h1 className="text-header2 m-4 mx-0 mb-4">
-            Designing our characters
-          </h1>
-          <p className="text-body">
-            The roster of Gizmo Go-Kartz characters is designed to be both
-            approachable and scalable. Characters are build using a standardized
-            body base reminiscent of Nintendo's Miis, with heads and faces being
-            easy to customize. This allows ease of character production for a
-            high-quality base cast with room for future expansion. Character are
-            also meant to have easily identifiable heads, as those are what will
-            be most prominently seen by players in-game. The original plan for
-            the roster was to include multiple RIT mascots, but this caused
-            complications with requiring approval from third parties to include
-            their mascots. As a result, most of the characters are original
-            students, and only 2 are mascots with approval.
-          </p>
-          <div className="text-black">
-            <CharacterCarousel
-              contentClass="lg:max-w-[60%]"
-              mappedContent={(c) => {
-                return (
-                  <div className="">
-                    <DialogHeader className="text-left">
-                      <DialogTitle>
-                        <h3 className="text-header3 mb-[1rem]">
-                          {c.name}
-                          {c.occupation ? ` - ${c.occupation}` : ""}
-                        </h3>
-                      </DialogTitle>
-                    </DialogHeader>
-                    <div className="h-[60vh] overflow-auto flex flex-col items-center text-center bg-gray-200">
-                      <img
-                        src={c.conceptImgUrl}
-                        alt={`${c.name} concept`}
-                        className="mb-[1rem] h-[70%]"
-                      />
-                      <DialogDescription>
-                        <p className="text-body text-black">
-                          {c.devDescription}
-                        </p>
-                      </DialogDescription>
-                    </div>
-                  </div>
-                );
-              }}
-            />
-          </div>
-        </div>
+        <ProcessDropdown
+          value="characters"
+          trigger={
+            <h1 className="text-header2 my-4">Designing Our Characters</h1>
+          }
+          content={
+            <>
+              <p className="text-body">
+                The roster of Gizmo Go-Kartz characters is designed to be both
+                approachable and scalable. Characters are build using a
+                standardized body base reminiscent of Nintendo's Miis, with
+                heads and faces being easy to customize. This allows ease of
+                character production for a high-quality base cast with room for
+                future expansion. Character are also meant to have easily
+                identifiable heads, as those are what will be most prominently
+                seen by players in-game. The original plan for the roster was to
+                include multiple RIT mascots, but this caused complications with
+                requiring approval from third parties to include their mascots.
+                As a result, most of the characters are original students, and
+                only 2 are mascots with approval.
+              </p>
+              <div className="text-black">
+                <CharacterCarousel
+                  contentClass="lg:max-w-[60%]"
+                  mappedContent={(c) => {
+                    return (
+                      <div className="">
+                        <DialogHeader className="text-left">
+                          <DialogTitle>
+                            <h3 className="text-header3 mb-[1rem]">
+                              {c.name}
+                              {c.occupation ? ` - ${c.occupation}` : ""}
+                            </h3>
+                          </DialogTitle>
+                        </DialogHeader>
+                        <div className="h-[60vh] overflow-auto flex flex-col items-center text-center bg-gray-200">
+                          <img
+                            src={c.conceptImgUrl}
+                            alt={`${c.name} concept`}
+                            className="mb-[1rem] h-[70%]"
+                          />
+                          <DialogDescription>
+                            <p className="text-body text-black">
+                              {c.devDescription}
+                            </p>
+                          </DialogDescription>
+                        </div>
+                      </div>
+                    );
+                  }}
+                />
+              </div>
+            </>
+          }
+        />
 
         {/* Developing Game Section */}
-        <div>
-          <h1 className="text-header2 mt-[2rem] m-4 mx-0 mb-4">
-            Developing the Game
-          </h1>
-          <div className="pb-[1rem] flex md:flex-row flex-col items-stretch">
-            <img
-              src="images/GSP.jpg"
-              alt="Picture of GSP"
-              className="md:mr-[2rem] mb-[2rem] md:mt-0 self-center md:self-end md:w-[400px] w-full md:w-1/4 max-h-[300px]"
-            />
-            <p className="text-body">
-              Our Game Systems Programming (GSP) team is the backbone of our
-              game's functionality. Given the scope of their work, they follow
-              several practices to stay organized and efficient. To keep the
-              GitHub repo clean and avoid merge conflicts, GSP uses feature
-              branches and forks for development. All code pushed to main goes
-              through a pull request and approval process, ensuring no broken
-              code makes it into the daily builds. Daily builds of the game are
-              created to quickly catch and resolve functionality issues, and to
-              ensure there's always an updated version ready for playtesting.
-              The team regularly peer programs, which helps with idea
-              brainstorming, faster debugging, and overall productivity. As GSP
-              remote lead Logan Larrondo said, “Peer programming helps
-              brainstorm ideas, debug faster, and is often more efficient than
-              working alone.” To stay on track, the team fills out daily Google
-              Forms, logging progress and helping with planning. When major bugs
-              appear, GSP tackles them together, through research, code reviews,
-              or simply joining a call to talk things out.
-            </p>
-          </div>
-        </div>
+        <ProcessDropdown
+          value="development"
+          trigger={<h1 className="text-header2 my-4">Developing The Game</h1>}
+          content={
+            <div className="pb-[1rem] flex md:flex-row flex-col items-stretch">
+              <img
+                src="images/GSP.jpg"
+                alt="Picture of GSP"
+                className="md:mr-[2rem] mb-[2rem] md:mt-0 self-center md:self-end md:w-[400px] w-full md:w-1/4 max-h-[300px]"
+              />
+              <p className="text-body">
+                Our Game Systems Programming (GSP) team is the backbone of our
+                game's functionality. Given the scope of their work, they follow
+                several practices to stay organized and efficient. To keep the
+                GitHub repo clean and avoid merge conflicts, GSP uses feature
+                branches and forks for development. All code pushed to main goes
+                through a pull request and approval process, ensuring no broken
+                code makes it into the daily builds. Daily builds of the game
+                are created to quickly catch and resolve functionality issues,
+                and to ensure there's always an updated version ready for
+                playtesting. The team regularly peer programs, which helps with
+                idea brainstorming, faster debugging, and overall productivity.
+                As GSP remote lead Logan Larrondo said, “Peer programming helps
+                brainstorm ideas, debug faster, and is often more efficient than
+                working alone.” To stay on track, the team fills out daily
+                Google Forms, logging progress and helping with planning. When
+                major bugs appear, GSP tackles them together, through research,
+                code reviews, or simply joining a call to talk things out.
+              </p>
+            </div>
+          }
+        />
 
         {/* Tracks Section */}
-        <h1 className="text-header2 m-4 mx-0 mb-4">Building our Tracks</h1>
-        <p className="mb-8 text-body">
-          The tracks of Gizmo Go-Kartz are largely based on real RIT locations
-          with original twists. With an initial plan of 4 tracks per cup and
-          some difficulty guidelines from the creative director, research into
-          the location of basis and difficulty level is conducted. Once
-          complete, sketches of the track layouts are created, then translated
-          to a 3D model in Blender, with environmental background details being
-          added as the finishing touch. In addition, track layouts are tweaked
-          in response to feedback from playtesters.
-        </p>
-
-        <Tabs defaultValue="0" className="w-[90vw] pb-[2rem]">
-          <TabsList className="flex flex-wrap h-full pl-0">
-            {tracks.map((t) => {
-              return (
-                <TabsTrigger value={tracks.indexOf(t).toString()}>
-                  {t.name}
-                </TabsTrigger>
-              );
-            })}
-            <TabsTrigger value="cut">Back Burner Content</TabsTrigger>
-          </TabsList>
-          {tracks.map((t) => {
-            return (
-              <TabsContent
-                value={tracks.indexOf(t).toString()}
-                className="text-white text-body"
-              >
-                <div className="bg-linear-to-b from-[#F66624] to-[#D84B3A] p-5 xl:rounded-e-2xl rounded-b-2xl mb-3 h-[70vh]">
-                  {t.devDescription}
-                </div>
-              </TabsContent>
-            );
-          })}
-          <TabsContent value="cut">
-            <div className="bg-linear-to-b from-[#F66624] to-[#D84B3A] p-5 xl:rounded-e-2xl rounded-b-2xl mb-3 *:mb-5 h-[70vh] ">
-              <div className="max-h-full overflow-y-auto">
-                <h2 className="text-header3 mb-[1rem]">
-                  On the back burner...
-                </h2>
-                <div className="flex flex-col md:flex-row">
-                  <div className="md:mr-10">
-                    <h3 className="text-header4 mb-3">Quarter-Mile</h3>
-                    <p className="text-body mb-[1rem]">
-                      A track based on RIT's Quarter Mile, a long pathway
-                      connecting the dorm buildings to the academic buildings,
-                      was developed and tested several times, but eventually cut
-                      from the track roster. The layout's size and length made
-                      it highly challenging to scale down to the level of a
-                      track with 3 laps.
-                    </p>
+        <ProcessDropdown
+          value="tracks"
+          trigger={<h1 className="text-header2 my-4">Building Our Tracks</h1>}
+          content={
+            <>
+              <p className="mb-8 text-body">
+                The tracks of Gizmo Go-Kartz are largely based on real RIT
+                locations with original twists. With an initial plan of 4 tracks
+                per cup and some difficulty guidelines from the creative
+                director, research into the location of basis and difficulty
+                level is conducted. Once complete, sketches of the track layouts
+                are created, then translated to a 3D model in Blender, with
+                environmental background details being added as the finishing
+                touch. In addition, track layouts are tweaked in response to
+                feedback from playtesters.
+              </p>
+              <Tabs defaultValue="0" className="w-[90vw] pb-[2rem]">
+                <TabsList className="flex flex-wrap h-full pl-0">
+                  {tracks.map((t) => {
+                    return (
+                      <TabsTrigger value={tracks.indexOf(t).toString()}>
+                        {t.name}
+                      </TabsTrigger>
+                    );
+                  })}
+                  <TabsTrigger value="cut">Back Burner Content</TabsTrigger>
+                </TabsList>
+                {tracks.map((t) => {
+                  return (
+                    <TabsContent
+                      value={tracks.indexOf(t).toString()}
+                      className="text-white text-body"
+                    >
+                      <div className="bg-linear-to-b from-[#F66624] to-[#D84B3A] p-5 xl:rounded-e-2xl rounded-b-2xl mb-3 h-[70vh]">
+                        {t.devDescription}
+                      </div>
+                    </TabsContent>
+                  );
+                })}
+                <TabsContent value="cut">
+                  <div className="bg-linear-to-b from-[#F66624] to-[#D84B3A] p-5 xl:rounded-e-2xl rounded-b-2xl mb-3 *:mb-5 h-[70vh] ">
+                    <div className="max-h-full overflow-y-auto">
+                      <h2 className="text-header3 mb-[1rem]">
+                        On the back burner...
+                      </h2>
+                      <div className="flex flex-col md:flex-row">
+                        <div className="md:mr-10">
+                          <h3 className="text-header4 mb-3">Quarter-Mile</h3>
+                          <p className="text-body mb-[1rem]">
+                            A track based on RIT's Quarter Mile, a long pathway
+                            connecting the dorm buildings to the academic
+                            buildings, was developed and tested several times,
+                            but eventually cut from the track roster. The
+                            layout's size and length made it highly challenging
+                            to scale down to the level of a track with 3 laps.
+                          </p>
+                        </div>
+                        <div className="">
+                          <img
+                            src="images/tracks/dev-quarter-mile.jpg"
+                            alt="Quarter Mile Sketch"
+                            className="md:max-w-80 lg:max-w-[25vw] mb-[1rem]"
+                          />
+                        </div>
+                      </div>
+                      <div className="flex flex-col md:flex-row-reverse">
+                        <div className="md:ml-10">
+                          <h1 className="text-header4 mb-3">Global Village</h1>
+                          <p className="text-body mb-[1rem]">
+                            A track based on RIT's Global Village was drafted
+                            early into development, going through several
+                            proposed layouts that emphasized several branching
+                            pathways. However, there was no concrete plan for
+                            the track, and it ultimately was not modeled or
+                            incorporated into the roster.
+                          </p>
+                        </div>
+                        <div className="">
+                          <img
+                            src="images/tracks/dev-global-village.jpg"
+                            alt="Global Village Sketch"
+                            className="md:max-w-40 lg:max-w-[20vw] mb-[1rem]"
+                          />
+                        </div>
+                      </div>
+                      <div>
+                        <h1 className="text-header4 mb-3">
+                          Other Cut Track Concepts
+                        </h1>
+                        <ul className="list-disc ml-5 *:mb-2 text-body">
+                          <li>
+                            <b>The SHED:</b> An early drafted track based on the
+                            Student Hall for Exploration and Development (SHED).
+                            The track was never given a proper layout and cut
+                            for similar reasons to the Quarter Mile.
+                          </li>
+                          <li>
+                            <b>RIT Woods:</b> A track was modeled and visualized
+                            based on the woods near Grace Watson Hall to
+                            contrast with the urban visuals of the other tracks.
+                            The design ended up not aligning thematically or
+                            feeling recognizable as an RIT location, and thus
+                            was cut.
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
                   </div>
-                  <div className="">
-                    <img
-                      src="images/tracks/dev-quarter-mile.jpg"
-                      alt="Quarter Mile Sketch"
-                      className="md:max-w-80 lg:max-w-[25vw] mb-[1rem]"
-                    />
-                  </div>
-                </div>
-                <div className="flex flex-col md:flex-row-reverse">
-                  <div className="md:ml-10">
-                    <h1 className="text-header4 mb-3">Global Village</h1>
-                    <p className="text-body mb-[1rem]">
-                      A track based on RIT's Global Village was drafted early
-                      into development, going through several proposed layouts
-                      that emphasized several branching pathways. However, there
-                      was no concrete plan for the track, and it ultimately was
-                      not modeled or incorporated into the roster.
-                    </p>
-                  </div>
-                  <div className="">
-                    <img
-                      src="images/tracks/dev-global-village.jpg"
-                      alt="Global Village Sketch"
-                      className="md:max-w-40 lg:max-w-[20vw] mb-[1rem]"
-                    />
-                  </div>
-                </div>
-                <div>
-                  <h1 className="text-header4 mb-3">
-                    Other Cut Track Concepts
-                  </h1>
-                  <ul className="list-disc ml-5 *:mb-2 text-body">
-                    <li>
-                      <b>The SHED:</b> An early drafted track based on the
-                      Student Hall for Exploration and Development (SHED). The
-                      track was never given a proper layout and cut for similar
-                      reasons to the Quarter Mile.
-                    </li>
-                    <li>
-                      <b>RIT Woods:</b> A track was modeled and visualized based
-                      on the woods near Grace Watson Hall to contrast with the
-                      urban visuals of the other tracks. The design ended up not
-                      aligning thematically or feeling recognizable as an RIT
-                      location, and thus was cut.
-                    </li>
-                  </ul>
-                </div>
-              </div>
-            </div>
-          </TabsContent>
-        </Tabs>
+                </TabsContent>
+              </Tabs>
+            </>
+          }
+        />
       </main>
     </>
   );


### PR DESCRIPTION
### Process Page Dropdowns
On mobile devices, all sections of the process page will be collapsed dropdowns that the user can open one-at-a-time to read the content for each heading. The PC layout is configured to be the same as before, by removing this interaction.

### Other Fixes
* Fixed dark gray line on About Us
* Fixed colors on item card